### PR TITLE
ENG-4969 Unprotected-GET-REST-api

### DIFF
--- a/microservices/springboot-agenda/src/main/java/com/entando/springbootagenda/config/SecurityConfiguration.java
+++ b/microservices/springboot-agenda/src/main/java/com/entando/springbootagenda/config/SecurityConfiguration.java
@@ -16,6 +16,7 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableMethodSecurity
 public class SecurityConfiguration {
 
+    public static final String AGENDA_BUNDLE_API = "/api/**";
     public final JwtAuthConverter jwtAuthConverter;
 
     public SecurityConfiguration(JwtAuthConverter jwtAuthConverter) {
@@ -27,8 +28,9 @@ public class SecurityConfiguration {
         return http
                 .csrf(csrf -> csrf.disable()) //NOSONAR
                 .authorizeHttpRequests(requests -> requests
-                        .requestMatchers(HttpMethod.OPTIONS,"/api/**").permitAll()
-                        .requestMatchers("/api/**").authenticated()
+                        .requestMatchers(HttpMethod.OPTIONS, AGENDA_BUNDLE_API).permitAll()
+                        .requestMatchers(HttpMethod.GET, AGENDA_BUNDLE_API).permitAll()
+                        .requestMatchers(AGENDA_BUNDLE_API).authenticated()
                         .requestMatchers("/swagger-ui/**").permitAll()
                         .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers("/v3/api-docs/**").permitAll()

--- a/microservices/springboot-agenda/src/main/java/com/entando/springbootagenda/controller/ContactController.java
+++ b/microservices/springboot-agenda/src/main/java/com/entando/springbootagenda/controller/ContactController.java
@@ -31,7 +31,6 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @RestController()
 @RequestMapping("/api")
-@SecurityRequirement(name = "agenda_auth")
 public class ContactController {
     private final Logger log = LoggerFactory.getLogger(ContactController.class);
     private final ContactService contactService;
@@ -42,7 +41,6 @@ public class ContactController {
     }
 
     @GetMapping("/contacts")
-    @PreAuthorize("hasRole('admin')")
     public ResponseEntity<List<ContactRecord>> getAllContacts(@ParameterObject Pageable pageable) {
         log.debug("REST request to get all Contacts");
 
@@ -54,7 +52,6 @@ public class ContactController {
     }
 
     @GetMapping("/contacts/{id}")
-    @PreAuthorize("hasRole('admin')")
     public ResponseEntity<ContactRecord> getContact(@PathVariable Long id) {
         log.debug("REST request to get the contact with id {}", id);
 
@@ -66,6 +63,7 @@ public class ContactController {
 
     @DeleteMapping("/contacts/{id}")
     @PreAuthorize("hasRole('admin')")
+    @SecurityRequirement(name = "agenda_auth")
     public ResponseEntity<String> deleteContact(@PathVariable Long id) {
         log.debug("REST request to delete contact: {}", id);
 
@@ -76,6 +74,7 @@ public class ContactController {
 
     @PostMapping("/contact")
     @PreAuthorize("hasRole('admin')")
+    @SecurityRequirement(name = "agenda_auth")
     public ResponseEntity<ContactRecord> createContact(@RequestBody ContactRecord contact) throws URISyntaxException {
         log.debug("REST request to create a NEW contact: {}", contact );
 
@@ -88,6 +87,7 @@ public class ContactController {
 
     @PutMapping("/contacts/{id}")
     @PreAuthorize("hasRole('admin')")
+    @SecurityRequirement(name = "agenda_auth")
     public ResponseEntity<ContactRecord> updateContact(@PathVariable(value = "id") final Long id, @RequestBody ContactRecord contact) {
         log.debug("REST request to update contact: {}", id);
 

--- a/microservices/springboot-agenda/src/test/java/com/entando/springbootagenda/controller/ContactControllerIT.java
+++ b/microservices/springboot-agenda/src/test/java/com/entando/springbootagenda/controller/ContactControllerIT.java
@@ -28,7 +28,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
@@ -70,7 +69,6 @@ class ContactControllerIT extends PostgreSqlTestContainer {
 
     @Test
     @Transactional
-    @WithMockUser(username="admin",roles={"admin"})
     void getAllUsersShouldReturnTheCurrentOrderedListOfUsersByIdAsc() throws Exception {
         contactMockMvc
                 .perform(get("/api/contacts?sort=id,asc").accept(MediaType.APPLICATION_JSON))
@@ -90,7 +88,6 @@ class ContactControllerIT extends PostgreSqlTestContainer {
 
     @Test
     @Transactional
-    @WithMockUser(username="admin",roles={"admin"})
     void getAllUsersShouldReturnTheCurrentOrderedListOfUsersByNameAsc() throws Exception {
         contactMockMvc
                 .perform(get("/api/contacts?sort=name,asc").accept(MediaType.APPLICATION_JSON))
@@ -110,7 +107,6 @@ class ContactControllerIT extends PostgreSqlTestContainer {
 
     @Test
     @Transactional
-    @WithMockUser(username="admin",roles={"admin"})
     void getUserWithItsIdShouldReturnTheCorrectUser() throws Exception {
         Long currentFirstContactId = contactsList.get(0).getId();
         Long currentSecondContactId = contactsList.get(1).getId();
@@ -138,7 +134,6 @@ class ContactControllerIT extends PostgreSqlTestContainer {
 
     @Test
     @Transactional
-    @WithMockUser(username="admin",roles={"admin"})
     void getUserWithId1234ShouldThrowANotFoundException() throws Exception {
         contactMockMvc
                 .perform(get("/api/contacts/1234").accept(MediaType.APPLICATION_JSON))


### PR DESCRIPTION
Make GET invocation generally available, restricting access only to POST and PUT.
Update Swagger accordingly